### PR TITLE
bump v0.24.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,7 +1308,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc-client"
-version = "0.24.3"
+version = "0.24.4"
 dependencies = [
  "anyhow",
  "clap 3.2.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-client"
-version = "0.24.3"
+version = "0.24.4"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
bumped to the wrong version #12 earlier since `v0.24.4` was released 2 days ago: https://github.com/FuelLabs/sway/pull/2794